### PR TITLE
constant stream added - outputs given vector

### DIFF
--- a/streams.h
+++ b/streams.h
@@ -81,6 +81,19 @@ private:
 };
 
 /**
+ * @brief Stream outputing a constant vector
+ */
+struct const_stream : stream {
+    const_stream(const json &config, const std::size_t osize);
+
+    vec_cview next() override;
+
+private:
+    static void fromHex(std::vector<value_type> &res, const std::string &hex);
+    std::vector<value_type> _data;
+};
+
+/**
  * @brief Stream outputing a constant value for n iterations
  */
 struct repeating_stream : stream {


### PR DESCRIPTION
- Hexcoded vector value given in the config `{"value":"f0f1f2f3"}`
- Outputs the given vector with each `next()` call
- Value size has to match `osize` strictly to avoid potential configuration errors
- Hexcoded value has to be of even length, strictly hexcoded characters
- Simple tests provided
- Clang-format used to format the files

Our use-case: Let seed govern the input data generation, fix key to some particular values. With this we can pre-generate the key to the config file and let the seed to the rest with the input stream, which are usually more complex. In our scenario we want to have 3 different random inputs per 3 random keys (9 in total).

This stream is also a nice building block for composition, e.g., for XORing with HW / CTR streams. 